### PR TITLE
DD-1492 Library extending ocfl-java to support layered storage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,1 @@
-# configuration for authorized and required reviewers
-* @DANS-KNAW/dataversedans-leads
-
-# code
-# no overrides
-
-# policies
-/.github/PULL_REQUEST_TEMPLATE.md @DANS-KNAW/dataversedans-leads
-/.github/CODEOWNERS @DANS-KNAW/dataversedans-leads
+* @DANS-KNAW/core-systems-leads

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Fixes DD-
 
 # Notify
 
-@DANS-KNAW/dataversedans
+@DANS-KNAW/core-systems

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-layer-store-lib</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/nl/knaw/dans/lib/ocflext/RoundTripTest.java
+++ b/src/test/java/nl/knaw/dans/lib/ocflext/RoundTripTest.java
@@ -22,6 +22,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.layerstore.LayerManager;
 import nl.knaw.dans.layerstore.LayerManagerImpl;
+import nl.knaw.dans.layerstore.ZipArchiveProvider;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ public class RoundTripTest extends LayerDatabaseFixture {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        layerManager = new LayerManagerImpl(stagingDir, archiveDir, new DirectExecutorService());
+        layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         repo = createRepoBuilder(createLayeredStorage(layerManager), new NTupleOmitPrefixStorageLayoutConfig().setDelimiter(":").setTupleSize(3)).build();
     }
 


### PR DESCRIPTION
Fixes DD-1492

# Description of changes
Uses `dans-layer-store-lib` to implement a layered storage back-end for `ocfl-java`.

# Notify

@DANS-KNAW/core-systems 
